### PR TITLE
Don't append '?' without query parameters

### DIFF
--- a/lib/rack-cas/url.rb
+++ b/lib/rack-cas/url.rb
@@ -39,6 +39,9 @@ module RackCAS
             qv.delete key
           end
         end
+        if u.query_values.empty?
+          u.query_values = nil
+        end
       end
     end
 

--- a/spec/rack-cas/cas_request_spec.rb
+++ b/spec/rack-cas/cas_request_spec.rb
@@ -12,7 +12,7 @@ describe CASRequest do
     before { get '/private/something?ticket=ST-0123456789ABCDEFGHIJKLMNOPQRS' }
     its(:ticket_validation?) { should be_true }
     its(:ticket) { should eql 'ST-0123456789ABCDEFGHIJKLMNOPQRS' }
-    its(:service_url) { should eql 'http://example.org/private/something?' }
+    its(:service_url) { should eql 'http://example.org/private/something' }
     its(:logout?) { should be_false }
     its(:single_sign_out?) { should be_false }
   end
@@ -46,7 +46,7 @@ describe CASRequest do
   context 'logout request' do
     before { get '/logout' }
     its(:logout?) { should be_true }
-    its(:service_url) { should eql 'http://example.org/logout?' }
+    its(:service_url) { should eql 'http://example.org/logout' }
     its(:single_sign_out?) { should be_false }
     its(:ticket_validation?) { should be_false }
   end

--- a/spec/rack-cas/server_spec.rb
+++ b/spec/rack-cas/server_spec.rb
@@ -26,6 +26,6 @@ describe RackCAS::Server do
 
   describe :validate_service_url do    
     subject { server.send(:validate_service_url, service_url, ticket) }
-    its(:to_s) { should eql 'http://example.com/cas/serviceValidate?service=http%3A%2F%2Fexample.org%2Fwhatever%3F&ticket=ST-0123456789ABCDEFGHIJKLMNOPQRS'}
+    its(:to_s) { should eql 'http://example.com/cas/serviceValidate?service=http%3A%2F%2Fexample.org%2Fwhatever&ticket=ST-0123456789ABCDEFGHIJKLMNOPQRS'}
   end
 end

--- a/spec/rack/cas_spec.rb
+++ b/spec/rack/cas_spec.rb
@@ -23,6 +23,12 @@ describe Rack::CAS do
     subject { get '/private?search=blah&ticket=ST-0123456789ABCDEFGHIJKLMNOPQRS' }
     its(:status) { should eql 302 }
     its(:location) { should eql 'http://example.org/private?search=blah' }
+
+    context 'without additional query parameters' do
+      subject { get '/private?ticket=ST-0123456789ABCDEFGHIJKLMNOPQRS' }
+      its(:status) { should eql 302 }
+      its(:location) { should eql 'http://example.org/private' }
+    end
   end
 
   describe 'logout request' do


### PR DESCRIPTION
When an URL without query parameters is opened, users end up with a "?" added to the end of said URL.

```
   http://example.org/whatever
=> http://example.com/cas/login?service=http%3A%2F%2Fexample.org%2Fwhatever
=> http://example.org/whatever?ticket=ST-0123456789ABCDEFGHIJKLMNOPQRS
=> http://example.org/whatever? <<< don't like this
```

This PR removes this unnecessary question mark. :smile: 
