### PR TITLE
Redirect to SSO when ticket is invalid

### DIFF
--- a/spec/rack/cas_spec.rb
+++ b/spec/rack/cas_spec.rb
@@ -40,6 +40,12 @@ describe Rack::CAS do
       it { should have_key 'mail' }
       it { should_not have_key 'title' }
     end
+
+    context 'with an invalid ticket' do
+      before { RackCAS::ServiceValidationResponse.any_instance.stub(:user) { raise RackCAS::ServiceValidationResponse::TicketInvalidError } }
+      its(:status) { should eql 302 }
+      its(:location) { should eql 'http://example.com/cas/login?service=http%3A%2F%2Fexample.org%2Fprivate%3Fsearch%3Dblah' }
+    end
   end
 
   describe 'logout request' do


### PR DESCRIPTION
We saw some occurrences of `RackCAS::ServiceValidationResponse::AuthenticationFailure` with failure message "Ticket 'ST-1368175095-2n1213vkujosbwu0qqngmbjqxb3fwsz5cy3k375s' already consumed".

When an invalid ticket is presented, rack-cas should redirect to the SSO to get a new service ticket. This is exactly what this PR does.
