### PR TITLE
Accept service tickets shorter than 32 characters.

### DIFF
--- a/lib/rack-cas/cas_request.rb
+++ b/lib/rack-cas/cas_request.rb
@@ -26,9 +26,11 @@ class CASRequest
   end
 
   def ticket_validation?
-    # The CAS protocol specifies 32 characters as the minimum length of a
-    # service ticket (including ST-) http://www.jasig.org/cas/protocol
-    !!(@request.get? && ticket_param && ticket_param.to_s =~ /\AST\-[^\s]{29}/)
+    # The CAS protocol specifies that services must support tickets of
+    # *up to* 32 characters in length (including ST-), and recommendes
+    # that services accept tickets up to 256 characters long.
+    # http://www.jasig.org/cas/protocol
+    !!(@request.get? && ticket_param && ticket_param.to_s =~ /\AST\-[^\s]{,253}\Z/)
   end
 
   def path_matches?(strings_or_regexps)


### PR DESCRIPTION
The CAS protocol specification (http://www.jasig.org/cas/protocol),
section 3.1.1, say the following about ticket lengths:

  Services MUST be able to accept service tickets of up to 32
  characters in length. It is RECOMMENDED that services support
  service tickets of up to 256 characters in length.

This is not a requirement that tickets be at least 32 characters long,
but a requirement that services have to accept tickets at least that
long.  Valid tickets can be shorter than that.
