### PR TITLE
Valid service tickets can be shorter than 32 characters, take 2.

### DIFF
--- a/lib/rack-cas/cas_request.rb
+++ b/lib/rack-cas/cas_request.rb
@@ -26,9 +26,11 @@ class CASRequest
   end
 
   def ticket_validation?
-    # The CAS protocol specifies 32 characters as the minimum length of a
-    # service ticket (including ST-) http://www.jasig.org/cas/protocol
-    !!(@request.get? && ticket_param && ticket_param.to_s =~ /\AST\-[^\s]{29}/)
+    # The CAS protocol specifies that services must support tickets of
+    # *up to* 32 characters in length (including ST-), and recommendes
+    # that services accept tickets up to 256 characters long.
+    # http://www.jasig.org/cas/protocol
+    !!(@request.get? && ticket_param && ticket_param.to_s =~ /\AST\-[^\s]{1,253}\Z/)
   end
 
   def path_matches?(strings_or_regexps)

--- a/spec/rack-cas/cas_request_spec.rb
+++ b/spec/rack-cas/cas_request_spec.rb
@@ -30,7 +30,7 @@ describe CASRequest do
   end
 
   context 'short ticket' do
-    before { get '/private/something?ticket=ST-0123456789' }
+    before { get '/private/something?ticket=ST-' }
     its(:ticket_validation?) { should be_false }
     its(:ticket) { should be_nil }
   end


### PR DESCRIPTION
Require tickets to have at least 1 additional character after the "ST-" prefix; modified the 'short ticket' spec to match this rule.
