### PR TITLE
Configure extra attributes for `Rack::FakeCAS`

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -128,9 +128,18 @@ Integration testing using something like [Capybara](http://jnicklas.github.com/c
     require 'rack/fake_cas'
     use Rack::FakeCAS
 
+In addition you can pass a Hash to configure extra attributes for predefined
+usernames.
+
+    use Rack::FakeCAS, {}, {'john' => {'name' => 'John Doe'}}
+
 If you are using Rails, FakeCAS is automatically used in the test environment by default. If you would like to activate it in any other environment, add the following to the corresponding `config/environments/<env>.rb`:
 
     config.rack_cas.fake = true
+
+You can also configure extra attribute mappings through the Rails config:
+
+    config.rack_cas.fake_attributes = { 'john' => { 'name' => 'John Doe' } }
 
 Then you can simply do the following in your integration tests in order to log in.
 

--- a/lib/rack-cas/railtie.rb
+++ b/lib/rack-cas/railtie.rb
@@ -5,7 +5,7 @@ module RackCAS
     initializer 'rack_cas.initialize' do |app|
       if config.rack_cas.fake || (config.rack_cas.fake.nil? && Rails.env.test?)
         require 'rack/fake_cas'
-        app.middleware.use Rack::FakeCAS, config.rack_cas
+        app.middleware.use Rack::FakeCAS, config.rack_cas, config.rack_cas.fake_attributes
       elsif !config.rack_cas.server_url.nil? # for backwards compatibility
         require 'rack/cas'
         app.middleware.use Rack::CAS, config.rack_cas

--- a/lib/rack/fake_cas.rb
+++ b/lib/rack/fake_cas.rb
@@ -2,9 +2,10 @@ require 'rack'
 require 'rack-cas/cas_request'
 
 class Rack::FakeCAS
-  def initialize(app, config={})
+  def initialize(app, config={}, attributes_config={})
     @app = app
     @config = config || {}
+    @attributes_config = attributes_config || {}
   end
 
   def call(env)
@@ -17,9 +18,10 @@ class Rack::FakeCAS
 
     case @request.path_info
     when '/login'
+      username = @request.params['username']
       @request.session['cas'] = {}
-      @request.session['cas']['user'] = @request.params['username']
-      @request.session['cas']['extra_attributes'] = {}
+      @request.session['cas']['user'] = username
+      @request.session['cas']['extra_attributes'] = @attributes_config.fetch(username, {})
       redirect_to @request.params['service']
 
     when '/logout'

--- a/spec/rack/fake_cas_spec.rb
+++ b/spec/rack/fake_cas_spec.rb
@@ -56,4 +56,23 @@ describe Rack::FakeCAS do
     its(:status) { should eql 401 }
     its(:body) { should eql 'Authorization Required' }
   end
+
+  describe 'extra attributes' do
+    def app
+      Rack::FakeCAS.new(CasTestApp.new, {}, {
+                          'janed0' => {
+                            'name' => 'Jane Doe',
+                            'email' => 'janed0@gmail.com'}
+                        })
+    end
+
+    before { get '/login', username: 'janed0', service: 'http://example.org/private' }
+
+    describe 'session' do
+      subject { last_request.session['cas'] }
+      it { should_not be_nil }
+      its(['extra_attributes']) { should eql({'name' => 'Jane Doe',
+                                              'email' => 'janed0@gmail.com'}) }
+    end
+  end
 end


### PR DESCRIPTION
Our application relies on some data passed through the `extra_attributes`. To simulate that workflow in the tests it would be great to have `Rack::FakeCAS` return these attributes.

This patch allows you to configure `extra_attributes` for testing.
The configuration is passed when instantiating the `Rack::FakeCAS` middleware:

```
use Rack::FakeCAS, {}, {"jane" => {"name" => "Jane Doe"}}
```

The Hash has the following structure:

```
{<username> => <extra attributes Hash>}
```

As Rails users most likely do not configure `Rack::FakeCAS` themselves they can
pass the configuration throuth `Rails.application.config`:

```
config.rack_cas.fake_attributes = {"jane" => {"name" => "Jane Doe"}}
```
### Sidenote

I included a commit to remove trailing whitespace in the files I touched. Please let me know if you want to keep the files as they are and I'm going to remove that patch.
