### PR TITLE
added missing extension.

### DIFF
--- a/lib/generators/cas_session_store_migration_generator.rb
+++ b/lib/generators/cas_session_store_migration_generator.rb
@@ -21,6 +21,6 @@ class CasSessionStoreMigrationGenerator < Rails::Generators::Base
   end
 
   def create_migration_file
-    migration_template 'migration.rb', 'db/migrate/create_rack_cas_sessions'
+    migration_template 'migration.rb', 'db/migrate/create_rack_cas_sessions.rb'
   end
 end


### PR DESCRIPTION
Fixed a typo. Without giving an extension the command `rails g cas_session_store_migration` has resulted in creating the migration without the ruby extension so that the file was skipped by `ActiveRecord::Migration`

I am using Rails4.1 and Ruby2.1:

``` zsh
nirnanaaa@Magmaw ~/Documents/CASApp $ rails g cas_session_store_migration                                                                                         
   create  db/migrate/20140417170814_create_rack_cas_sessions.rb
```
