### PR TITLE
Include rspec-its and fix other be_truth/be_false deprecation warnings

### DIFF
--- a/rack-cas.gemspec
+++ b/rack-cas.gemspec
@@ -18,6 +18,7 @@ spec = Gem::Specification.new do |s|
   s.add_dependency 'addressable', '~> 2.3'
   s.add_dependency 'nokogiri', '~> 1.5'
   s.add_development_dependency 'rspec', '~> 2.11'
+  s.add_development_dependency 'rspec-its', '~> 1.0'
   s.add_development_dependency 'rack-test', '~> 0.6'
   s.add_development_dependency 'webmock', '~> 1.6'
 end

--- a/spec/rack-cas/cas_request_spec.rb
+++ b/spec/rack-cas/cas_request_spec.rb
@@ -10,59 +10,59 @@ describe CASRequest do
 
   context 'ticket validation request' do
     before { get '/private/something?ticket=ST-0123456789ABCDEFGHIJKLMNOPQRS' }
-    its(:ticket_validation?) { should be_true }
+    its(:ticket_validation?) { should be true }
     its(:ticket) { should eql 'ST-0123456789ABCDEFGHIJKLMNOPQRS' }
     its(:service_url) { should eql 'http://example.org/private/something' }
-    its(:logout?) { should be_false }
-    its(:single_sign_out?) { should be_false }
+    its(:logout?) { should be false }
+    its(:single_sign_out?) { should be false }
   end
 
   context 'ticket POST' do
     before { post '/private/something?ticket=ST-0123456789ABCDEFGHIJKLMNOPQRS&post=POST' }
-    its(:ticket_validation?) { should be_false }
-    its(:ticket) { should be_nil }
+    its(:ticket_validation?) { should be false }
+    its(:ticket) { should be nil }
   end
 
   context 'invalid ticket' do
     before { get '/private/something?ticket=BLARG' }
-    its(:ticket_validation?) { should be_false }
-    its(:ticket) { should be_nil }
+    its(:ticket_validation?) { should be false }
+    its(:ticket) { should be nil }
   end
 
   context 'short ticket' do
     before { get '/private/something?ticket=ST-' }
-    its(:ticket_validation?) { should be_false }
-    its(:ticket) { should be_nil }
+    its(:ticket_validation?) { should be false }
+    its(:ticket) { should be nil }
   end
 
   context 'single sign out request' do
     before { post "/?logoutRequest=#{URI.encode(fixture('single_sign_out_request.xml'))}" }
     its(:ticket) { should eql 'ST-0123456789ABCDEFGHIJKLMNOPQRS' }
-    its(:single_sign_out?) { should be_true }
-    its(:logout?) { should be_false }
-    its(:ticket_validation?) { should be_false }
+    its(:single_sign_out?) { should be true }
+    its(:logout?) { should be false }
+    its(:ticket_validation?) { should be false }
   end
 
   context 'logout request' do
     before { get '/logout' }
-    its(:logout?) { should be_true }
+    its(:logout?) { should be true }
     its(:service_url) { should eql 'http://example.org/logout' }
-    its(:single_sign_out?) { should be_false }
-    its(:ticket_validation?) { should be_false }
+    its(:single_sign_out?) { should be false }
+    its(:ticket_validation?) { should be false }
   end
 
   describe :path_matches? do
     context 'matching path' do
       before { get '/match/this/path/does' }
       ['/match', /this/, ['/blah', /match/]].each do |matcher|
-        it { expect(subject.path_matches? matcher).to be_true }
+        it { expect(subject.path_matches? matcher).to be true }
       end
     end
 
     context 'not-matching path' do
       before { get '/something/else/that/doesnt' }
       ['match', /match/, ['/foo', /bar/], [], nil, ''].each do |matcher|
-        it { expect(subject.path_matches? matcher).to be_false }
+        it { expect(subject.path_matches? matcher).to be false }
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 $:.unshift File.expand_path(File.dirname(__FILE__) + '/../lib')
 $:.unshift File.expand_path(File.dirname(__FILE__))
 
+require 'rspec/its'
 require 'bundler/setup'
 require 'rspec'
 require 'rack'


### PR DESCRIPTION
Pretty straight forward. Basically fixes some deprecation warnings with minimal changes to the specs.

Here are a list of the warnings given by rspec.

---

Deprecation Warnings:

Use of rspec-core's `its` method is deprecated. Use the rspec-its gem
instead. Called from

`be_false` is deprecated. Use `be_falsey` (for Ruby's conditional
semantics) or `be false` (for exact `== false` equality) instead. Called
from

`be_true` is deprecated. Use `be_truthy` (for Ruby's conditional
semantics) or `be true` (for exact `== true` equality) instead. Called
from

78 deprecation warnings total