### PR TITLE
Option to not validate CAS servers SSL certificate

### DIFF
--- a/lib/rack-cas/configuration.rb
+++ b/lib/rack-cas/configuration.rb
@@ -1,6 +1,6 @@
 module RackCAS
   class Configuration
-    SETTINGS = [:server_url, :session_store, :exclude_path, :exclude_paths, :extra_attributes_filter]
+    SETTINGS = [:server_url, :session_store, :exclude_path, :exclude_paths, :extra_attributes_filter, :verify_ssl_cert]
 
     SETTINGS.each do |setting|
       attr_accessor setting
@@ -8,6 +8,10 @@ module RackCAS
       define_method "#{setting}?" do
         !(send(setting).nil? || send(setting) == [])
       end
+    end
+
+    def initialize
+      @verify_ssl_cert = true
     end
 
     def extra_attributes_filter

--- a/lib/rack-cas/service_validation_response.rb
+++ b/lib/rack-cas/service_validation_response.rb
@@ -83,7 +83,10 @@ module RackCAS
       return @response unless @response.nil?
 
       http = Net::HTTP.new(@url.host, @url.inferred_port)
-      http.use_ssl = true if @url.scheme == 'https'
+      if @url.scheme == 'https'
+        http.use_ssl = true
+        http.verify_mode = RackCAS.config.verify_ssl_cert? ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
+      end
 
       http.start do |conn|
         @response = conn.get(@url.request_uri, REQUEST_HEADERS)


### PR DESCRIPTION
This can be nice when using a development or staging CAS server.

Resolves https://github.com/biola/rack-cas/issues/19