### PR TITLE
Better support and documentation for extra_attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Extra Attributes
 You can whitelist which extra attributes to keep.
 In your `config/application.rb`:
 ```ruby
-config.rack_cas.extra_attributes_filter = %w(some_attribute some_other_attribute yet_a_third)
+config.rack_cas.extra_attributes_filter = %w(some_attribute some_other_attribute)
 ```
 
 Excluding Paths

--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ Single sign out support outside of Rails is currently untested. We'll be adding 
 Configuration
 =============
 
+Extra Attributes
+----------------
+
+You can whitelist which extra attributes to keep.
+In your `config/application.rb`:
+```ruby
+config.rack_cas.extra_attributes_filter = %w(some_attribute some_other_attribute yet_a_third)
+```
+
 Excluding Paths
 ---------------
 

--- a/lib/rack/cas.rb
+++ b/lib/rack/cas.rb
@@ -71,7 +71,9 @@ class Rack::CAS
   end
 
   def store_session(request, user, ticket, extra_attrs = {})
-    extra_attrs.select! { |key, val| RackCAS.config.extra_attributes_filter.map(&:to_s).include? key.to_s }
+    if RackCAS.config.extra_attributes_filter?
+      extra_attrs.select! { |key, val| RackCAS.config.extra_attributes_filter.map(&:to_s).include? key.to_s }
+    end
 
     request.session['cas'] = { 'user' => user, 'ticket' => ticket, 'extra_attributes' => extra_attrs }
   end


### PR DESCRIPTION
The extra_attributes_filter is currently undocumented.
By default it prevents any extra_attributes from being stored. Which is not what people expect.