### PR TITLE
added saml validation and configuration option

### DIFF
--- a/lib/rack-cas/configuration.rb
+++ b/lib/rack-cas/configuration.rb
@@ -1,6 +1,6 @@
 module RackCAS
   class Configuration
-    SETTINGS = [:server_url, :session_store, :exclude_path, :exclude_paths, :extra_attributes_filter, :verify_ssl_cert, :renew]
+    SETTINGS = [:server_url, :session_store, :exclude_path, :exclude_paths, :extra_attributes_filter, :verify_ssl_cert, :renew, :use_saml_validation]
 
     SETTINGS.each do |setting|
       attr_accessor setting

--- a/lib/rack-cas/saml_validation_response.rb
+++ b/lib/rack-cas/saml_validation_response.rb
@@ -1,0 +1,119 @@
+module RackCAS
+  class SAMLValidationResponse
+    class AuthenticationFailure < StandardError; end
+    class RequestInvalidError < AuthenticationFailure; end
+    class TicketInvalidError < AuthenticationFailure; end
+    class ServiceInvalidError < AuthenticationFailure; end
+
+    REQUEST_HEADERS = {
+      'Accept' => '*/*',
+      'Content-Type' => 'application/soap+xml; charset=utf-8'
+    }
+
+    def initialize(url, ticket)
+      @url = URL.parse(url)
+      @ticket = ticket
+    end
+
+    def user
+      if success?
+        xml.at('//Response/Assertion/AuthenticationStatement/Subject/NameIdentifier').text
+      else
+        case failure_code
+        when 'INVALID_REQUEST'
+          raise RequestInvalidError, failure_message
+        when 'INVALID_TICKET'
+          raise TicketInvalidError, failure_message
+        when 'INVALID_SERVICE'
+          raise ServiceInvalidError, failure_message
+        else
+          raise AuthenticationFailure, failure_message
+        end
+      end
+    end
+
+    def extra_attributes
+      attrs = {}
+
+      raise AuthenticationFailure, failure_message unless success?
+
+      xml.at('//Response/Assertion/AttributeStatement').children.each do |node|
+        key = node.at('@AttributeName')
+
+        if key
+          values = node.xpath('AttributeValue').map { |n| n.text }
+
+          values = values.first if values.size == 1
+
+          attrs[key.text] = values
+        end
+      end
+
+      attrs
+    end
+
+    protected
+
+    def success?
+      @success ||= xml.at('//Response/Status/StatusCode/@Value').text == 'saml1p:Success'
+    end
+
+    def authentication_failure
+      @authentication_failure ||= !@success
+    end
+
+    def failure_message
+      if authentication_failure
+        xml.at('//Response/Status/StatusMessage').text.strip
+      end
+    end
+
+    def failure_code
+      if authentication_failure
+        xml.at('//Response/Status/StatusCode/@Value').text
+      end
+    end
+
+    def response
+      require 'net/http'
+      return @response unless @response.nil?
+
+      http = Net::HTTP.new(@url.host, @url.inferred_port)
+
+      if @url.scheme == 'https'
+        http.use_ssl = true
+        http.verify_mode = RackCAS.config.verify_ssl_cert? ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
+      end
+
+      now = Time.now
+
+      data = %Q~<?xml version='1.0'?>
+      <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+        <SOAP-ENV:Header/>
+        <SOAP-ENV:Body>
+          <samlp:Request xmlns:samlp="urn:oasis:names:tc:SAML:1.0:protocol" MajorVersion="1" MinorVersion="1" RequestID="_#{ip_address}.#{now.to_i}" IssueInstant="#{now.strftime("%FT%TZ")}">
+            <samlp:AssertionArtifact>#{@ticket}</samlp:AssertionArtifact>
+          </samlp:Request>
+        </SOAP-ENV:Body>
+      </SOAP-ENV:Envelope>~
+
+      @response = http.post(@url.request_uri, data, REQUEST_HEADERS)
+    end
+
+    def xml
+      return @xml unless @xml.nil?
+
+      @xml = Nokogiri::XML(response.body).remove_namespaces!
+    end
+
+    def ip_address
+      require 'socket'
+
+      return @ip_address unless @ip_address.nil?
+
+      @ip_address = Socket.ip_address_list.detect{ |intf|
+          intf.ipv4? and !intf.ipv4_loopback? and !intf.ipv4_multicast? and !intf.ipv4_private?
+        }.ip_address
+    end
+  end
+end

--- a/lib/rack-cas/saml_validation_response.rb
+++ b/lib/rack-cas/saml_validation_response.rb
@@ -1,6 +1,7 @@
 module RackCAS
   class SAMLValidationResponse
     class AuthenticationFailure < StandardError; end
+    class TicketInvalidError < AuthenticationFailure; end
 
     REQUEST_HEADERS = {
       'Accept' => '*/*',
@@ -93,9 +94,13 @@ module RackCAS
 
       return @ip_address unless @ip_address.nil?
 
-      @ip_address = Socket.ip_address_list.detect{ |intf|
-          intf.ipv4? and !intf.ipv4_loopback? and !intf.ipv4_multicast? and !intf.ipv4_private?
-        }.ip_address
+      begin
+        @ip_address = Socket.ip_address_list.detect{ |intf|
+            intf.ipv4? and !intf.ipv4_loopback? and !intf.ipv4_multicast? and !intf.ipv4_private?
+          }.ip_address
+      rescue
+        @ip_address = '127.0.0.1'
+      end
     end
   end
 end

--- a/lib/rack-cas/saml_validation_response.rb
+++ b/lib/rack-cas/saml_validation_response.rb
@@ -1,9 +1,6 @@
 module RackCAS
   class SAMLValidationResponse
     class AuthenticationFailure < StandardError; end
-    class RequestInvalidError < AuthenticationFailure; end
-    class TicketInvalidError < AuthenticationFailure; end
-    class ServiceInvalidError < AuthenticationFailure; end
 
     REQUEST_HEADERS = {
       'Accept' => '*/*',
@@ -19,16 +16,7 @@ module RackCAS
       if success?
         xml.at('//Response/Assertion/AuthenticationStatement/Subject/NameIdentifier').text
       else
-        case failure_code
-        when 'INVALID_REQUEST'
-          raise RequestInvalidError, failure_message
-        when 'INVALID_TICKET'
-          raise TicketInvalidError, failure_message
-        when 'INVALID_SERVICE'
-          raise ServiceInvalidError, failure_message
-        else
-          raise AuthenticationFailure, failure_message
-        end
+        raise AuthenticationFailure, failure_message
       end
     end
 
@@ -65,12 +53,6 @@ module RackCAS
     def failure_message
       if authentication_failure
         xml.at('//Response/Status/StatusMessage').text.strip
-      end
-    end
-
-    def failure_code
-      if authentication_failure
-        xml.at('//Response/Status/StatusCode/@Value').text
       end
     end
 

--- a/lib/rack/cas.rb
+++ b/lib/rack/cas.rb
@@ -25,7 +25,7 @@ class Rack::CAS
 
       begin
         user, extra_attrs = get_user(request.url, cas_request.ticket)
-      rescue RackCAS::ServiceValidationResponse::TicketInvalidError
+      rescue RackCAS::ServiceValidationResponse::TicketInvalidError, RackCAS::SAMLValidationResponse::TicketInvalidError
         log env, 'rack-cas: Invalid ticket. Redirecting to CAS login.'
 
         return redirect_to server.login_url(cas_request.service_url).to_s

--- a/spec/fixtures/failure_saml_response.xml
+++ b/spec/fixtures/failure_saml_response.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+<SOAP-ENV:Body>
+    <saml1p:Response xmlns:saml1p="urn:oasis:names:tc:SAML:1.0:protocol" IssueInstant="2015-05-28T13:06:30.450Z" MajorVersion="1" MinorVersion="1" Recipient="https://example.org/" ResponseID="_79c15e5e3270e26c854eb8e0d9d38d7e">
+    <saml1p:Status>
+        <saml1p:StatusCode Value="saml1p:RequestDenied"/>
+        <saml1p:StatusMessage>ticket 'ST-718673-vjzOrfL70HlOb5TviNTT-odo-665.example.org' not recognized</saml1p:StatusMessage>
+    </saml1p:Status>
+</saml1p:Response>
+</SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/spec/fixtures/saml_validation_response.xml
+++ b/spec/fixtures/saml_validation_response.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+  <SOAP-ENV:Body>
+    <saml1p:Response xmlns:saml1p="urn:oasis:names:tc:SAML:1.0:protocol" IssueInstant="2015-05-28T12:29:16.050Z" MajorVersion="1" MinorVersion="1" Recipient="https://example.org/" ResponseID="_0179b384038958ff14e7b00a037445a5">
+      <saml1p:Status>
+        <saml1p:StatusCode Value="saml1p:Success"/>
+      </saml1p:Status>
+      <saml1:Assertion xmlns:saml1="urn:oasis:names:tc:SAML:1.0:assertion" AssertionID="_09f7176170c5d360f221e1d6fe37cfa3" IssueInstant="2015-05-28T12:29:16.050Z" Issuer="localhost" MajorVersion="1" MinorVersion="1">
+        <saml1:Conditions NotBefore="2015-05-28T12:29:16.050Z" NotOnOrAfter="2015-05-28T12:29:46.050Z">
+          <saml1:AudienceRestrictionCondition>
+            <saml1:Audience>https://example.org/</saml1:Audience>
+          </saml1:AudienceRestrictionCondition>
+        </saml1:Conditions>
+        <saml1:AuthenticationStatement AuthenticationInstant="2015-05-28T12:29:16.014Z" AuthenticationMethod="urn:oasis:names:tc:SAML:1.0:am:unspecified">
+          <saml1:Subject>
+            <saml1:NameIdentifier>johnd0</saml1:NameIdentifier>
+            <saml1:SubjectConfirmation>
+              <saml1:ConfirmationMethod>urn:oasis:names:tc:SAML:1.0:cm:artifact</saml1:ConfirmationMethod>
+            </saml1:SubjectConfirmation>
+          </saml1:Subject>
+        </saml1:AuthenticationStatement>
+        <saml1:AttributeStatement>
+          <saml1:Subject>
+            <saml1:NameIdentifier>johnd0</saml1:NameIdentifier>
+            <saml1:SubjectConfirmation>
+              <saml1:ConfirmationMethod>urn:oasis:names:tc:SAML:1.0:cm:artifact</saml1:ConfirmationMethod>
+            </saml1:SubjectConfirmation>
+          </saml1:Subject>
+          <saml1:Attribute AttributeName="eduPersonNickname" AttributeNamespace="http://www.ja-sig.org/products/cas/">
+            <saml1:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">John</saml1:AttributeValue>
+          </saml1:Attribute>
+        </saml1:AttributeStatement>
+      </saml1:Assertion>
+    </saml1p:Response>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/spec/rack-cas/saml_validation_response_spec.rb
+++ b/spec/rack-cas/saml_validation_response_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+require 'rack-cas/saml_validation_response'
+
+describe RackCAS::SAMLValidationResponse do
+  before { stub_request(:post, /samlValidate/).to_return(headers: { 'Accept' => '*/*', 'Content-Type' => 'application/soap+xml; charset=utf-8' }, body: fixture(fixture_filename)) }
+  let(:url) { 'http://example.com/cas/samlValidate?TARGET=http%3A%2F%2Fexample.org%2F' }
+  let(:ticket) { 'ST-718673-vjzOrfL70HlOb5TviNTT-odo-665.example.org' }
+  let(:response) { RackCAS::SAMLValidationResponse.new(url, ticket) }
+  subject { response }
+
+  context 'saml_validation_response' do
+    let(:fixture_filename) { 'saml_validation_response.xml' }
+
+    its(:user) { should eql 'johnd0' }
+
+    describe :extra_attributes do
+      subject { response.extra_attributes }
+      it { should be_kind_of Hash }
+      its(['eduPersonNickname']) { should eql 'John' }
+    end
+  end
+
+  context 'failure response' do
+    let(:fixture_filename) { 'failure_saml_response.xml' }
+
+    it 'should raise an authentication failure exception' do
+      expect{ subject.user }.to raise_error RackCAS::SAMLValidationResponse::AuthenticationFailure, "ticket 'ST-718673-vjzOrfL70HlOb5TviNTT-odo-665.example.org' not recognized"
+      expect{ subject.extra_attributes}.to raise_error RackCAS::SAMLValidationResponse::AuthenticationFailure, "ticket 'ST-718673-vjzOrfL70HlOb5TviNTT-odo-665.example.org' not recognized"
+    end
+  end
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,11 @@ RSpec.configure do |config|
       headers: {'Content-Type' => 'text/xml'},
       body: fixture('rubycas_service_response.xml')
     )
+
+    stub_request(:post, /samlValidate/).to_return(
+      headers: {'Content-Type' => 'text/xml'},
+      body: fixture('saml_validation_response.xml')
+    )
   end
 end
 


### PR DESCRIPTION
We only pass attributes via SAML, so I added a new response class for SAML validation and a config option that let's you use it.