### PR TITLE
Allow for explicit passing of 'config.rack_cas.fake = false' when set…

### DIFF
--- a/lib/rack-cas/configuration.rb
+++ b/lib/rack-cas/configuration.rb
@@ -1,6 +1,6 @@
 module RackCAS
   class Configuration
-    SETTINGS = [:server_url, :session_store, :exclude_path, :exclude_paths, :extra_attributes_filter, :verify_ssl_cert, :renew, :use_saml_validation]
+    SETTINGS = [:fake, :server_url, :session_store, :exclude_path, :exclude_paths, :extra_attributes_filter, :verify_ssl_cert, :renew, :use_saml_validation]
 
     SETTINGS.each do |setting|
       attr_accessor setting

--- a/spec/rack/cas_spec.rb
+++ b/spec/rack/cas_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Rack::CAS do
   let(:server_url) { 'http://example.com/cas' }
-  let(:app_options) { {} }
+  let(:app_options) { {'fake' => false} }
   let(:ticket) { 'ST-0123456789ABCDEFGHIJKLMNOPQRS' }
 
   def app


### PR DESCRIPTION
…ting up Rails environment.

Use case: culturally we set up three environments for each application dev, test, and prod. Attempted to get people to move away from using 'test' with regards to our Rails envrionments, but was met with silence. Would like to be able to use this gem as it has desired features over ruby-cas-client, but without being able to explicitly pass in a 'false' value for the fake flag we won't be able to.