### PR TITLE
Setting verify_ssl_cert was not taking effect

### DIFF
--- a/lib/rack-cas/configuration.rb
+++ b/lib/rack-cas/configuration.rb
@@ -6,7 +6,7 @@ module RackCAS
       attr_accessor setting
 
       define_method "#{setting}?" do
-        !(send(setting).nil? || send(setting) == [])
+        !(send(setting).nil? || send(setting) == [] || send(setting) == false)
       end
     end
 

--- a/spec/rack-cas/configuration_spec.rb
+++ b/spec/rack-cas/configuration_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+require 'rack-cas/configuration'
+
+describe RackCAS::Configuration do
+    
+  it 'returns true for attribute? if the attribute is neither nil, an empty array, nor false' do
+    configuration = RackCAS::Configuration.new
+    configuration.update(renew: true, verify_ssl_cert: true, server_url: 'https://cas.example.com/', exclude_paths: ['/api', /\.json/])
+    expect(configuration.renew?).to be true
+    expect(configuration.verify_ssl_cert?).to be true
+    expect(configuration.server_url?).to be true
+    expect(configuration.exclude_paths?).to be true
+  end
+
+  it 'returns false for attribute? if the attribute is either nil, an empty array, or false' do
+    configuration = RackCAS::Configuration.new
+    configuration.update(renew: nil, verify_ssl_cert: false, server_url: 'https://cas.example.com/', exclude_paths: [])
+    expect(configuration.renew?).to be false
+    expect(configuration.verify_ssl_cert?).to be false
+    expect(configuration.exclude_paths?).to be false
+  end
+
+end


### PR DESCRIPTION
I found that setting the configuration option, `verify_ssl_cert`, to `false` was not having any effect.  This was due to the method, `verify_ssl_cert?`, returning `true` since `verify_ssl_cert` was neither `nil` nor an empty array.  I added a condition to check if the setting is `false` and that seems to work.