### PR TITLE
Use Rails.application instead of specific app name

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ config.rack_cas.session_store = RackCAS::ActiveRecordStore
 Edit your `config/initializers/session_store.rb` file with the following:
 ```ruby
 require 'rack-cas/session_store/rails/active_record'
-YourApp::Application.config.session_store ActionDispatch::Session::RackCasActiveRecordStore
+Rails.application.config.session_store ActionDispatch::Session::RackCasActiveRecordStore
 ```
 Run:
 ```ruby


### PR DESCRIPTION
If you want to rename the rails app this creates more overhead just use Rails.application