### PR TITLE
More secure session handling

### DIFF
--- a/lib/rack-cas/session_store/active_record.rb
+++ b/lib/rack-cas/session_store/active_record.rb
@@ -20,7 +20,11 @@ module RackCAS
         sid = generate_sid
         data = nil
       else
-        session = Session.where(session_id: sid).first || {}
+        unless session = Session.where(session_id: sid).first
+          session = {}
+          # force generation of new sid since there is no associated session
+          sid = generate_sid
+        end
         data = unpack(session['data'])
       end
 

--- a/lib/rack-cas/session_store/mongo.rb
+++ b/lib/rack-cas/session_store/mongo.rb
@@ -1,0 +1,45 @@
+module RackCAS
+  module MongoStore
+    def collection
+      @collection
+    end
+
+    def initialize(app, options = {})
+      require 'mongo'
+
+      unless options[:collection]
+        raise "To avoid creating multiple connections to MongoDB, " +
+              "the Mongo Session Store will not create it's own connection " +
+              "to MongoDB - you must pass in a collection with the :collection option"
+      end
+
+      @collection = options[:collection].respond_to?(:call) ? options[:collection].call : options[:collection]
+
+      super
+    end
+
+    private
+    def get_session(env, sid)
+      sid ||= generate_sid
+      session = collection.find(_id: sid).first || {}
+      [sid, unpack(session['data'])]
+    end
+
+    def set_session(env, sid, session_data, options = {})
+      sid ||= generate_sid
+      collection.update({'_id' => sid},
+                        {'_id' => sid, 'data' => pack(session_data), 'updated_at' => Time.now},
+                        upsert: true)
+      sid # TODO: return boolean, right?
+    end
+
+    def pack(data)
+      [Marshal.dump(data)].pack('m*')
+    end
+
+    def unpack(packed)
+      return nil unless packed
+      Marshal.load(packed.unpack('m*').first)
+    end
+  end
+end

--- a/lib/rack-cas/session_store/mongoid.rb
+++ b/lib/rack-cas/session_store/mongoid.rb
@@ -32,7 +32,11 @@ module RackCAS
         sid = generate_sid
         data = nil
       else
-        session = Session.where(_id: sid).first || {}
+        unless session = Session.where(_id: sid).first
+          session = {}
+          # force generation of new sid since there is no associated session
+          sid = generate_sid
+        end
         data = unpack(session['data'])
       end
 
@@ -49,7 +53,7 @@ module RackCAS
     end
 
     def destroy_session(env, sid, options)
-      session = Session.where(_id: sid).delete
+      Session.where(_id: sid).delete
 
       options[:drop] ? nil : generate_sid
     end

--- a/lib/rack-cas/session_store/rack/mongo.rb
+++ b/lib/rack-cas/session_store/rack/mongo.rb
@@ -1,0 +1,10 @@
+require 'rack-cas/session_store/mongo'
+require 'rack/session/abstract/id'
+
+module Rack
+  module Session
+    class RackCASMongoStore < Rack::Session::Abstract::ID
+      include RackCAS::MongoStore
+    end
+  end
+end

--- a/lib/rack-cas/session_store/rails/mongo.rb
+++ b/lib/rack-cas/session_store/rails/mongo.rb
@@ -1,0 +1,10 @@
+require 'rack-cas/session_store/mongo'
+require 'action_dispatch/middleware/session/abstract_store'
+
+module ActionDispatch
+  module Session
+    class RackCasMongoStore < AbstractStore
+      include RackCAS::MongoStore
+    end
+  end
+end

--- a/lib/rack/cas.rb
+++ b/lib/rack/cas.rb
@@ -38,7 +38,7 @@ class Rack::CAS
     if cas_request.logout?
       log env, 'rack-cas: Intercepting logout request.'
 
-      request.session.clear
+      request.session.send respond_to?(:destroy) ? :destroy : :clear
       return redirect_to server.logout_url(request.params).to_s
     end
 

--- a/lib/rack/fake_cas.rb
+++ b/lib/rack/fake_cas.rb
@@ -25,7 +25,7 @@ class Rack::FakeCAS
       redirect_to @request.params['service']
 
     when '/logout'
-      @request.session.clear
+      @request.session.send respond_to?(:destroy) ? :destroy : :clear
       redirect_to "#{@request.script_name}/"
 
     # built-in way to get to the login page without needing to return a 401 status


### PR DESCRIPTION
- If an existing session isn't found in the session store, assign a new
 session ID instead of reusing the given ID. This could prevent a
session fixation attack.
- If the session responds to #destroy use that method rather than #clear.

Thanks to hwilbanks@ranchopt.com for pointing this out.

@halloffame or @rift137 could I get this reviewed and merged quickly? Once it is I'll roll out a new gem version.