### PR TITLE
[WIP] Use CAS protocol 3.0 for service validation

### DIFF
--- a/lib/rack-cas/server.rb
+++ b/lib/rack-cas/server.rb
@@ -41,7 +41,8 @@ module RackCAS
 
     def validate_service_url(service_url, ticket)
       service_url = URL.parse(service_url).remove_param('ticket').to_s
-      @url.dup.append_path('serviceValidate').add_params(service: service_url, ticket: ticket)
+      # @url.dup.append_path('serviceValidate').add_params(service: service_url, ticket: ticket)
+      @url.dup.append_path('p3/serviceValidate').add_params(service: service_url, ticket: ticket)
     end
   end
 end


### PR DESCRIPTION
This is only meant as an example. Revert this commit and add a config
option instead. Examine the URI overview at
http://jasig.github.io/cas/4.1.x/protocol/CAS-Protocol-Specification.html#cas-uris
to see what endpoints change between protocol v2.0 and v3.0.