### PR TITLE
change jasig-style extra attributes parsing to handle deeply nested attributes

### DIFF
--- a/spec/fixtures/jasig_nested_service_response.xml
+++ b/spec/fixtures/jasig_nested_service_response.xml
@@ -1,0 +1,30 @@
+<cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
+  <cas:authenticationSuccess>
+    <cas:user>johnd0</cas:user>
+    <cas:attributes>
+      <cas:cn>johnd0</cas:cn>
+      <cas:title>Imaginary Person</cas:title>
+      <cas:employeeId>00000</cas:employeeId>
+      <cas:eduPersonEntitlement>urn:example:thing:admin,urn:example:whatsit:viewer</cas:eduPersonEntitlement>
+      <cas:eduPersonNickname>John</cas:eduPersonNickname>
+      <cas:sn>Doe</cas:sn>
+      <cas:mail>john.doe@example.com</cas:mail>
+      <cas:eduPersonPrincipalname>john.doe</cas:eduPersonPrincipalname>
+      <cas:department>Imaginary Department</cas:department>
+      <cas:eduPersonAffiliation>alumnus</cas:eduPersonAffiliation>
+      <cas:eduPersonAffiliation>employee</cas:eduPersonAffiliation>
+      <cas:memberOf>CN=Support,OU=Departments,DC=example,DC=com</cas:memberOf>
+      <cas:memberOf>CN=Testing,OU=Departments,DC=example,DC=com</cas:memberOf>
+      <cas:nestedAttrs>
+        <cas:attrType>first</cas:attrType>
+      </cas:nestedAttrs>
+      <cas:nestedAttrs>
+        <cas:attrType>second</cas:attrType>
+      </cas:nestedAttrs>
+      <cas:mixedAttrs>string value</cas:mixedAttrs>
+      <cas:mixedAttrs>
+        <cas:crazyAttr>crazy nested string</cas:crazyAttr>
+      </cas:mixedAttrs>
+    </cas:attributes>
+  </cas:authenticationSuccess>
+</cas:serviceResponse>

--- a/spec/rack-cas/service_validation_response_spec.rb
+++ b/spec/rack-cas/service_validation_response_spec.rb
@@ -44,6 +44,21 @@ describe RackCAS::ServiceValidationResponse do
     end
   end
 
+  context 'nested jasig-style response' do
+    let(:fixture_filename) { 'jasig_nested_service_response.xml' }
+
+    its(:user) { should eql 'johnd0' }
+
+    describe :extra_attributes do
+      subject { response.extra_attributes }
+      it { should be_kind_of Hash }
+      its(['eduPersonAffiliation']) { should eql ['alumnus', 'employee'] }
+      its(['eduPersonNickname']) { should eql 'John' }
+      its(['nestedAttrs']) { should eql [{'attrType' => 'first'}, {'attrType' => 'second'}] }
+      its(['mixedAttrs']) { should eql ['string value', {'crazyAttr' => 'crazy nested string'}] }
+    end
+  end
+
   context 'failure response' do
     let(:fixture_filename) { 'failure_service_response.xml' }
 


### PR DESCRIPTION
Previous behavior was to flatten nested attributes into a string when merging multiple attributes into a single array. This change borrows from the behavior of omniauth-cas, preserving nested attributes. I don't believe this will break backwards compatibility, as the existing behavior of non-nested multiple attributes is maintained and the behavior of nested multiple attributes was pretty unusable.