### PR TITLE
Rack 2.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,14 @@ script: bundle exec rspec
 before_install:
   # fixes Travis CI error: NoMethodError: undefined method `spec' for nil:NilClass
   - gem install bundler
+gemfile:
+  - gemfiles/rack-1.3.gemfile
+  - gemfiles/rack-2.0.gemfile
+matrix:
+  exclude:
+    - rvm: 1.9.3
+      gemfile: gemfiles/rack-2.0.gemfile
+    - rvm: 2.0.0
+      gemfile: gemfiles/rack-2.0.gemfile
+    - rvm: 2.1.8
+      gemfile: gemfiles/rack-2.0.gemfile

--- a/gemfiles/rack-1.3.gemfile
+++ b/gemfiles/rack-1.3.gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "rack", ">=1.3", "< 2.0.0.alpha"
+gemspec :path => "../"

--- a/gemfiles/rack-2.0.gemfile
+++ b/gemfiles/rack-2.0.gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "rack", "2.0.0.alpha"
+gemspec :path => "../"

--- a/rack-cas.gemspec
+++ b/rack-cas.gemspec
@@ -19,6 +19,6 @@ spec = Gem::Specification.new do |s|
   s.add_dependency 'nokogiri', '~> 1.5'
   s.add_development_dependency 'rspec', '~> 3.2'
   s.add_development_dependency 'rspec-its', '~> 1.0'
-  s.add_development_dependency 'rack-test', '~> 0.6'
+  s.add_development_dependency 'rack-test'#, '~> 0.6'
   s.add_development_dependency 'webmock', '~> 1.6'
 end

--- a/rack-cas.gemspec
+++ b/rack-cas.gemspec
@@ -14,7 +14,7 @@ spec = Gem::Specification.new do |s|
   s.email = 'adam@codenoble.com'
   s.homepage = 'https://github.com/biola/rack-cas'
   s.license = 'MIT'
-  s.add_dependency 'rack', '~> 1.3'
+  s.add_dependency 'rack', '>= 1.3'
   s.add_dependency 'addressable', '~> 2.3'
   s.add_dependency 'nokogiri', '~> 1.5'
   s.add_development_dependency 'rspec', '~> 3.2'

--- a/rack-cas.gemspec
+++ b/rack-cas.gemspec
@@ -19,6 +19,6 @@ spec = Gem::Specification.new do |s|
   s.add_dependency 'nokogiri', '~> 1.5'
   s.add_development_dependency 'rspec', '~> 3.2'
   s.add_development_dependency 'rspec-its', '~> 1.0'
-  s.add_development_dependency 'rack-test'#, '~> 0.6'
+  s.add_development_dependency 'rack-test', '>= 0.6'
   s.add_development_dependency 'webmock', '~> 1.6'
 end


### PR DESCRIPTION
Rack 2.0 changed the session storage api. Store, find and destroy methods were renamed.
see: rack/rack@4224c02