### PR TITLE
Exclude requests and Ignore 401 intercepts based on request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,29 @@ The same options can be passed to `FakeCAS`.
 use Rack::FakeCAS, exclude_path: '/api'
 ```
 
+Excluding Requests
+------------------
+
+If the path exclusion is not suitable to ignore the CAS authentication in some parts of your app, you can pass
+`exclude_request_validator` to the middleware with a custom validator. You need to pass a `Proc` object that will accept
+a `Rack::Request` object as a parameter.
+
+```ruby
+use Rack::CAS, server_url: '...', exclude_request_validator: Proc.new { |req| req.env['HTTP_CONTENT_TYPE'] == 'application/json' }
+```
+
+Ignore 401 Intercept
+--------------------
+
+For some requests you might want to ignore the 401 intercept made by the middleware. For example when we want CAS to
+authenticate API requests but leave the redirect handling to the client. For this you can use the
+`ignore_intercept_validator`. You need to pass a `Proc` object that will accept a `Rack::Request` object as a parameter.
+
+```ruby
+use Rack::CAS, server_url: '...', ignore_intercept_validator: Proc.new { |req| req.env['HTTP_CONTENT_TYPE'] == 'application/json' }
+use Rack::CAS, server_url: '...', ignore_intercept_validator: Proc.new { |req| req.env['PATH_INFO'] =~ 'api' }
+```
+
 SSL Cert Verification
 ---------------------
 

--- a/lib/rack-cas/cas_request.rb
+++ b/lib/rack-cas/cas_request.rb
@@ -1,6 +1,8 @@
 require 'nokogiri'
 
 class CASRequest
+  attr_reader :request
+
   def initialize(request)
     @request = request
   end

--- a/lib/rack-cas/configuration.rb
+++ b/lib/rack-cas/configuration.rb
@@ -1,6 +1,7 @@
 module RackCAS
   class Configuration
-    SETTINGS = [:fake, :server_url, :session_store, :exclude_path, :exclude_paths, :extra_attributes_filter, :verify_ssl_cert, :renew, :use_saml_validation]
+    SETTINGS = [:fake, :server_url, :session_store, :exclude_path, :exclude_paths, :extra_attributes_filter,
+                :verify_ssl_cert, :renew, :use_saml_validation, :ignore_intercept_validator, :exclude_request_validator]
 
     SETTINGS.each do |setting|
       attr_accessor setting

--- a/lib/rack/cas.rb
+++ b/lib/rack/cas.rb
@@ -16,9 +16,7 @@ class Rack::CAS
     request = Rack::Request.new(env)
     cas_request = CASRequest.new(request)
 
-    if cas_request.path_matches? RackCAS.config.exclude_path || RackCAS.config.exclude_paths
-      return @app.call(env)
-    end
+    return @app.call(env) if exclude_request?(cas_request)
 
     if cas_request.ticket_validation?
       log env, 'rack-cas: Intercepting ticket validation request.'
@@ -51,7 +49,7 @@ class Rack::CAS
 
     response = @app.call(env)
 
-    if response[0] == 401 # access denied
+    if response[0] == 401 && !ignore_intercept?(request) # access denied
       log env, 'rack-cas: Intercepting 401 access denied response. Redirecting to CAS login.'
 
       redirect_to server.login_url(request.url).to_s
@@ -64,6 +62,19 @@ class Rack::CAS
 
   def server
     @server ||= RackCAS::Server.new(RackCAS.config.server_url)
+  end
+
+  def ignore_intercept?(request)
+    return false if (validator = RackCAS.config.ignore_intercept_validator).nil?
+    validator.call(request)
+  end
+
+  def exclude_request?(cas_request)
+    if (validator = RackCAS.config.exclude_request_validator)
+      validator.call(cas_request.request)
+    else
+      cas_request.path_matches? RackCAS.config.exclude_path || RackCAS.config.exclude_paths
+    end
   end
 
   def get_user(service_url, ticket)

--- a/spec/rack/cas_spec.rb
+++ b/spec/rack/cas_spec.rb
@@ -76,10 +76,34 @@ describe Rack::CAS do
     its(:body) { should eql 'CAS Single-Sign-Out request intercepted.' }
   end
 
-  describe 'excluded request' do
+  describe 'excluded request by path' do
     let(:app_options) { { exclude_path: '/private', session_store: nil } }
 
     subject { get '/private' }
+    its(:status) { should eql 401 }
+    its(:body) { should eql 'Authorization Required' }
+  end
+
+  describe 'excluded request by request validator' do
+    let(:app_options) {
+      { exclude_request_validator: Proc.new { |req| req.env['HTTP_CONTENT_TYPE'] == 'application/json' },
+        session_store: nil }
+    }
+    subject { get '/private', nil, { 'HTTP_CONTENT_TYPE' => 'application/json' } }
+    its(:status) { should eql 401 }
+    its(:body) { should eql 'Authorization Required' }
+    it 'should not continue the execution' do
+      expect_any_instance_of(CASRequest).to_not receive(:ticket_validation?)
+      subject
+    end
+  end
+
+  describe 'ignore 401 intercept' do
+    let(:app_options) {
+      { ignore_intercept_validator: Proc.new { |req| req.env['HTTP_CONTENT_TYPE'] == 'application/json' },
+        session_store: nil }
+    }
+    subject { get '/private', nil, { 'HTTP_CONTENT_TYPE' => 'application/json' } }
     its(:status) { should eql 401 }
     its(:body) { should eql 'Authorization Required' }
   end


### PR DESCRIPTION
I needed to ignore request validation based on the request headers, for example the Content-type. And in some other cases I wanted the validation to be handled by CAS but I wanted the 401 instead of the 303 response (to handle the redirect in AngularJS for example).

To support this I added 2 config attributes `ignore_intercept_validator` and `exclude_request_validator`. They both receive a `Proc` object that is called with the current `Rack::Request` being handled. This way I can define my own methods to bypass validation or bypass the intercept.

A Rails example:
```ruby
App::Application.configure do
  ...
  config.rack_cas.ignore_intercept_validation = Proc.new do |req| 
    req.env['HTTP_CONTENT_TYPE'] == 'application/json'
  end
  ...
end
```