### PR TITLE
Add Sequel session store for Rack and Rails

### DIFF
--- a/lib/rack-cas/session_store/rack/sequel.rb
+++ b/lib/rack-cas/session_store/rack/sequel.rb
@@ -1,0 +1,10 @@
+require 'rack-cas/session_store/sequel'
+require 'rack/session/abstract/id'
+
+module Rack
+  module Session
+    class RackCasSequelStore < Rack::Session::Abstract::Persisted
+      include RackCAS::SequelStore
+    end
+  end
+end

--- a/lib/rack-cas/session_store/rails/sequel.rb
+++ b/lib/rack-cas/session_store/rails/sequel.rb
@@ -1,0 +1,10 @@
+require 'rack-cas/session_store/sequel'
+require 'action_dispatch/middleware/session/abstract_store'
+
+module ActionDispatch
+  module Session
+    class RackCasSequelStore < AbstractStore
+      include RackCAS::SequelStore
+    end
+  end
+end

--- a/lib/rack-cas/session_store/sequel.rb
+++ b/lib/rack-cas/session_store/sequel.rb
@@ -1,0 +1,64 @@
+require 'sequel'
+
+module RackCAS
+  module SequelStore
+    class Session < Sequel::Model; end
+
+    def self.destroy_session_by_cas_ticket(cas_ticket)
+      affected = Session.where(cas_ticket: cas_ticket).delete
+      affected == 1
+    end
+
+    def self.prune(after = nil)
+      after ||= Time.now - 2592000 # 30 days ago
+      Session.where { updated_at < after }.delete
+    end
+
+    private
+
+    def find_session(env, sid)
+      if sid.nil?
+        sid = generate_sid
+        data = nil
+      else
+        unless session = Session.first(session_id: sid)
+          session = Session.new
+          sid = generate_sid
+        end
+        data = unpack(session.data)
+      end
+
+      [sid, data]
+    end
+
+    def write_session(req, sid, session_data, options)
+      cas_ticket = (session_data['cas']['ticket'] unless session_data['cas'].nil?)
+      data = pack(session_data)
+
+      begin
+        if session = Session.find(session_id: sid)
+          session.update(data: data, cas_ticket: cas_ticket)
+        else
+          Session.create(session_id: sid, data: data, cas_ticket: cas_ticket)
+        end
+      rescue Sequel::Error
+        false
+      else
+        sid
+      end
+    end
+
+    def delete_session(req, sid, options)
+      Session.where(session_id: sid).delete
+      options[:drop] ? nil : generate_sid
+    end
+
+    def pack(data)
+      ::Base64.encode64(Marshal.dump(data)) if data
+    end
+
+    def unpack(data)
+      Marshal.load(::Base64.decode64(data)) if data
+    end
+  end
+end


### PR DESCRIPTION
Adds support for Rack ~> 2.0. It's not compatible with previous versions of Rack where you inherited from `Rack::Session::Abstract::ID`. At some point, if you guys want to keep it up with Rack, you'll need to change this in the Rack-specific session stores albeit, this change could be made compatible with previous versions because `ID` is inheriting from `Persisted` up until now, so that you can use them indistinctly.
