### PR TITLE
Allows the samlp namespace when validating the SAML response

### DIFF
--- a/lib/rack-cas/saml_validation_response.rb
+++ b/lib/rack-cas/saml_validation_response.rb
@@ -44,7 +44,7 @@ module RackCAS
     protected
 
     def success?
-      @success ||= xml.at('//Response/Status/StatusCode/@Value').text == 'saml1p:Success'
+      @success ||= xml.at('//Response/Status/StatusCode/@Value').text =~ /saml1?p:Success/
     end
 
     def authentication_failure


### PR DESCRIPTION
Our server responded with a `samlp` namespace, not `saml1p`. This PR allows either namespace when evaluating whether or not the SAML validation response was successful. Everything else worked well after making this change on our end.

This PR only supports `samlp` and `saml1p` namespaces, but there may be others out there ... I debated about ignoring the namespace and just checking for `Success`, but I didn't want to be too intrusive.

