### PR TITLE
Add fake_attributes to configuration settings.

### DIFF
--- a/lib/rack-cas/configuration.rb
+++ b/lib/rack-cas/configuration.rb
@@ -1,6 +1,6 @@
 module RackCAS
   class Configuration
-    SETTINGS = [:fake, :server_url, :session_store, :exclude_path, :exclude_paths, :extra_attributes_filter,
+    SETTINGS = [:fake, :fake_attributes, :server_url, :session_store, :exclude_path, :exclude_paths, :extra_attributes_filter,
                 :verify_ssl_cert, :renew, :use_saml_validation, :ignore_intercept_validator, :exclude_request_validator, :protocol,:redis_options]
 
 


### PR DESCRIPTION
Using the `fake_attributes` for testing was causing a "invalid setting" exception.