### PR TITLE
`delete_all` wrong number of arguments error on rails 5.1

### DIFF
--- a/lib/rack-cas/session_store/active_record.rb
+++ b/lib/rack-cas/session_store/active_record.rb
@@ -4,7 +4,7 @@ module RackCAS
     end
 
     def self.destroy_session_by_cas_ticket(cas_ticket)
-      affected = Session.delete_all(cas_ticket: cas_ticket)
+      affected = Session.where(cas_ticket: cas_ticket).delete_all
       affected == 1
     end
 


### PR DESCRIPTION
This little change will make SSO compatible with rails 5.1 while not breaking compatibility with rails4.