### PR TITLE
Add config param to support custom login_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ See the [example Sinatra app](https://gist.github.com/adamcrown/a7e7577594690335
 
 ### Single Sign Out ###
 
-You will need to store sessions in session store supported by Rack CAS. 
+You will need to store sessions in session store supported by Rack CAS.
 
 #### Active Record ####
 Add a migration that looks roughly like
@@ -166,6 +166,15 @@ a `Rack::Request` object as a parameter.
 
 ```ruby
 use Rack::CAS, server_url: '...', exclude_request_validator: Proc.new { |req| req.env['HTTP_CONTENT_TYPE'] == 'application/json' }
+```
+
+Service URL
+--------------------
+
+Sometimes you need to force the `service=` attribute on login requests, and not just use the request url in an automatic way.
+
+```ruby
+use Rack::CAS, service: 'http://anotherexample.com'
 ```
 
 Ignore 401 Intercept

--- a/lib/rack-cas/configuration.rb
+++ b/lib/rack-cas/configuration.rb
@@ -2,7 +2,7 @@ module RackCAS
   class Configuration
     SETTINGS = [:fake, :fake_attributes, :server_url, :session_store, :exclude_path, :exclude_paths, :extra_attributes_filter,
                 :verify_ssl_cert, :renew, :use_saml_validation, :ignore_intercept_validator, :exclude_request_validator, :protocol,
-                :redis_options, :login_url]
+                :redis_options, :login_url, :service]
 
 
     SETTINGS.each do |setting|

--- a/lib/rack-cas/configuration.rb
+++ b/lib/rack-cas/configuration.rb
@@ -1,7 +1,8 @@
 module RackCAS
   class Configuration
     SETTINGS = [:fake, :fake_attributes, :server_url, :session_store, :exclude_path, :exclude_paths, :extra_attributes_filter,
-                :verify_ssl_cert, :renew, :use_saml_validation, :ignore_intercept_validator, :exclude_request_validator, :protocol,:redis_options]
+                :verify_ssl_cert, :renew, :use_saml_validation, :ignore_intercept_validator, :exclude_request_validator, :protocol,
+                :redis_options, :login_url]
 
 
     SETTINGS.each do |setting|

--- a/lib/rack-cas/server.rb
+++ b/lib/rack-cas/server.rb
@@ -13,7 +13,7 @@ module RackCAS
       base_params = {service: service_url}
       base_params[:renew] = true if RackCAS.config.renew?
 
-      url = RackCAS.config.login_url? ? RackCAS.config.login_url : @url.dup.append_path('login')
+      url = RackCAS.config.login_url? ? RackCAS::URL.parse(RackCAS.config.login_url) : @url.dup.append_path('login')
       url.add_params(base_params.merge(params))
     end
 

--- a/lib/rack-cas/server.rb
+++ b/lib/rack-cas/server.rb
@@ -13,7 +13,8 @@ module RackCAS
       base_params = {service: service_url}
       base_params[:renew] = true if RackCAS.config.renew?
 
-      @url.dup.append_path('login').add_params(base_params.merge(params))
+      url = RackCAS.config.login_url? ? RackCAS.config.login_url : @url.dup.append_path('login')
+      url.add_params(base_params.merge(params))
     end
 
     def logout_url(params = {})

--- a/spec/rack-cas/server_spec.rb
+++ b/spec/rack-cas/server_spec.rb
@@ -23,6 +23,12 @@ describe RackCAS::Server do
       subject { server.login_url(service_url) }
       its(:to_s) { should eql 'http://example.com/cas/login?renew=true&service=http%3A%2F%2Fexample.org%2Fwhatever' }
     end
+
+    context 'with custom login_url' do
+      before { RackCAS.config.stub(login_url: 'http://example.com/cas/login?hi=bye') }
+      subject { server.login_url(service_url) }
+      its(:to_s) { should eql 'http://example.com/cas/login?hi=bye&service=http%3A%2F%2Fexample.org%2Fwhatever' }
+    end
   end
 
   describe :logout_url do
@@ -49,7 +55,7 @@ describe RackCAS::Server do
     its(:last) { should be_kind_of Hash }
   end
 
-  describe :validate_service_url do    
+  describe :validate_service_url do
     subject { server.send(:validate_service_url, service_url, ticket) }
     its(:to_s) { should eql 'http://example.com/cas/serviceValidate?service=http%3A%2F%2Fexample.org%2Fwhatever&ticket=ST-0123456789ABCDEFGHIJKLMNOPQRS'}
   end

--- a/spec/rack/cas_spec.rb
+++ b/spec/rack/cas_spec.rb
@@ -14,12 +14,6 @@ describe Rack::CAS do
     its(:status) { should eql 200 }
   end
 
-  describe 'auth required request' do
-    subject { get '/private' }
-    its(:status) { should eql 302 }
-    its(:location) { should match %r{http://example.com/cas/login\?service=http%3A%2F%2Fexample.org%2Fprivate} }
-  end
-
   describe 'ticket validation request' do
     subject { get '/private?search=blah&ticket=ST-0123456789ABCDEFGHIJKLMNOPQRS' }
     its(:status) { should eql 302 }
@@ -106,5 +100,20 @@ describe Rack::CAS do
     subject { get '/private', nil, { 'HTTP_CONTENT_TYPE' => 'application/json' } }
     its(:status) { should eql 401 }
     its(:body) { should eql 'Authorization Required' }
+  end
+
+  describe 'auth required request' do
+    describe 'without service configured' do
+      subject { get '/private' }
+      its(:status) { should eql 302 }
+      its(:location) { should match %r{http://example.com/cas/login\?service=http%3A%2F%2Fexample.org%2Fprivate} }
+    end
+
+    describe 'with service configured' do
+      let(:app_options) { { 'fake' => false, service: 'https://example.info' } }
+      subject { get '/private' }
+      its(:status) { should eql 302 }
+      its(:location) { should match %r{http://example.com/cas/login\?service=https%3A%2F%2Fexample.info%2Fprivate} }
+    end
   end
 end


### PR DESCRIPTION
In one integration we just faced, we're required to pass some params to the login url as part of the query string. 

This new config param allows for that. 

PS: it would also allow to configure a whole different URL for login, but I don't know if that's a use case at all. 