### PR TITLE
Fix mongoid support for version > 5.x

### DIFF
--- a/lib/rack-cas/session_store/mongoid.rb
+++ b/lib/rack-cas/session_store/mongoid.rb
@@ -4,7 +4,7 @@ module RackCAS
       include Mongoid::Document
       include Mongoid::Timestamps
 
-      field :_id, type: String
+      field :_id, type: String unless Mongoid::VERSION.split('.')[0].to_i > 5
       if defined? Moped::BSON
         # Mongoid < 4
         field :data, type: Moped::BSON::Binary, default: Moped::BSON::Binary.new(:generic, Marshal.dump({}))


### PR DESCRIPTION
Mongoid v5 automatically creates the _id field, so it will cause conflicts.
```bash
  Defining this field would override the method '_id', which would cause issues with expectations around the original method and cause extremely hard to debug issues. The original method was defined in:
   Object: #<Module:0x00007fa3b51ee4b0>
   File: /Users/eagle/z/maikeji/sinatra_scaffold-master/vendor/bundle/ruby/2.6.0/gems/mongoid-7.1.0/lib/mongoid/fields.rb
   Line: 415
resolution:
  Use Mongoid.destructive_fields to see what names are not allowed, and don't use these names. These include names that also conflict with core Ruby methods on Object, Module, Enumerable, or included gems that inject methods into these or Mongoid internals.
bundler: failed to load command: puma (/Users/eagle/z/maikeji/sinatra_scaffold-master/vendor/bundle/ruby/2.6.0/bin/puma)
Mongoid::Errors::InvalidField:
message:
  Defining a field named '_id' is not allowed.
summary:
  Defining this field would override the method '_id', which would cause issues with expectations around the original method and cause extremely hard to debug issues. The original method was defined in:
   Object: #<Module:0x00007fa3b51ee4b0>
   File: /Users/eagle/z/maikeji/sinatra_scaffold-master/vendor/bundle/ruby/2.6.0/gems/mongoid-7.1.0/lib/mongoid/fields.rb
   Line: 415
resolution:
```