### PR TITLE
fix(cas_request): Allow ticket lengths greater than 256

### DIFF
--- a/lib/rack-cas/cas_request.rb
+++ b/lib/rack-cas/cas_request.rb
@@ -28,11 +28,7 @@ class CASRequest
   end
 
   def ticket_validation?
-    # The CAS protocol specifies that services must support tickets of
-    # *up to* 32 characters in length (including ST-), and recommendes
-    # that services accept tickets up to 256 characters long.
-    # http://www.jasig.org/cas/protocol
-    !!(@request.get? && ticket_param && ticket_param.to_s =~ /\AST\-[^\s]{1,253}\Z/)
+    !!(@request.get? && ticket_param && ticket_param.to_s =~ /\AST\-[^\s]+\Z/)
   end
 
   def path_matches?(strings_or_regexps)


### PR DESCRIPTION
While the recommended length of a ticket is 256, my company has decided
to exceed this number.  This change allows other establishments that
decide this to still use the gem.  Now the regular expression looks for
any ticket starting with ST- and one or more characters.