### PR TITLE
Add exclude_extra_attributes_from_session option to RackCAS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,11 @@ In your `config/application.rb`:
 config.rack_cas.extra_attributes_filter = %w(some_attribute some_other_attribute)
 ```
 
+Depending on your CAS implementation and space considerations, you can also choose to exclude **all** extra attributes from being saved in the session store.
+```ruby
+config.rack_cas.exclude_extra_attributes_from_session = true
+```
+
 Excluding Paths
 ---------------
 

--- a/lib/rack-cas/configuration.rb
+++ b/lib/rack-cas/configuration.rb
@@ -1,8 +1,9 @@
 module RackCAS
   class Configuration
-    SETTINGS = [:fake, :fake_attributes, :server_url, :session_store, :exclude_path, :exclude_paths, :extra_attributes_filter,
-                :verify_ssl_cert, :renew, :use_saml_validation, :ignore_intercept_validator, :exclude_request_validator, :protocol,
-                :redis_options, :login_url, :service]
+    SETTINGS = [:fake, :fake_attributes, :server_url, :session_store, :exclude_path, :exclude_paths,
+                :extra_attributes_filter, :exclude_extra_attributes_from_session, :verify_ssl_cert,
+                :renew, :use_saml_validation, :ignore_intercept_validator, :exclude_request_validator,
+                :protocol, :redis_options, :login_url, :service]
 
 
     SETTINGS.each do |setting|

--- a/lib/rack/cas.rb
+++ b/lib/rack/cas.rb
@@ -98,7 +98,11 @@ class Rack::CAS
       extra_attrs.select! { |key, val| RackCAS.config.extra_attributes_filter.map(&:to_s).include? key.to_s }
     end
 
-    request.session['cas'] = { 'user' => user, 'ticket' => ticket, 'extra_attributes' => extra_attrs }
+    request.session['cas'] = {
+      'user' => user,
+      'ticket' => ticket,
+      'extra_attributes' => RackCAS.config.exclude_extra_attributes_from_session? ? {} : extra_attrs
+    }
   end
 
   def redirect_to(url, status=302)

--- a/spec/rack/cas_spec.rb
+++ b/spec/rack/cas_spec.rb
@@ -35,6 +35,14 @@ describe Rack::CAS do
       it { should_not have_key 'title' }
     end
 
+    context 'with exclude_extra_attributes_from_session set' do
+      let(:app_options) { { exclude_extra_attributes_from_session: true } }
+
+      before { get '/private?ticket=ST-0123456789ABCDEFGHIJKLMNOPQRS' }
+      subject { last_request.session['cas']['extra_attributes'] }
+      it { should be_empty }
+    end
+
     context 'with an invalid ticket' do
       before { RackCAS::ServiceValidationResponse.any_instance.stub(:user) { raise RackCAS::ServiceValidationResponse::TicketInvalidError } }
       its(:status) { should eql 302 }


### PR DESCRIPTION
Our CAS implementation recently changed to have a very large array come back in `extra_attributes`. As a result we were accidentally exceeding the maximum allowed cookie size in one of our applications by putting the full list in the session store.

Our app doesn't need any of the extra attributes. As a work around I had to use the whitelist option with a dummy attribute value to get it to throw out all the unneeded data.

```ruby
config.rack_cas.extra_attributes_filter = %w(dummy_value)
```

I'm hoping this has values to others who want a straightforward way to throw out the extra attributes.