### PR TITLE
Allow to configure extra URL parameters for the validate_service URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,15 @@ The CAS standard allows for a `renew=true` parameter to be passed to the CAS ser
 config.rack_cas.renew = true
 ```
 
+Extra query parameters to serviceValidate
+-----------------------------------------
+
+Some CAS servers needs extra query parameters to be passed to serviceValidate. These can be configured by adding the following to `config/application.rb`:
+
+```ruby
+config.rack_cas.extra_params_validate = { key: 'verysecret', location: 'here' }
+```
+
 Integration
 ===========
 Your app should __return a [401 status](http://httpstatus.es/401)__ whenever a request is made that requires authentication. Rack-CAS will catch these responses and attempt to authenticate via your CAS server.

--- a/lib/rack-cas/configuration.rb
+++ b/lib/rack-cas/configuration.rb
@@ -2,7 +2,7 @@ module RackCAS
   class Configuration
     SETTINGS = [:fake, :fake_attributes, :server_url, :session_store, :exclude_path, :exclude_paths, :extra_attributes_filter,
                 :verify_ssl_cert, :renew, :use_saml_validation, :ignore_intercept_validator, :exclude_request_validator, :protocol,
-                :redis_options, :login_url, :service]
+                :redis_options, :login_url, :service, :extra_params_validate]
 
 
     SETTINGS.each do |setting|
@@ -15,6 +15,7 @@ module RackCAS
 
     def initialize
       @verify_ssl_cert = true
+      @extra_params_validate = {}
     end
 
     def extra_attributes_filter

--- a/spec/rack-cas/cas_request_spec.rb
+++ b/spec/rack-cas/cas_request_spec.rb
@@ -36,7 +36,7 @@ describe CASRequest do
   end
 
   context 'single sign out request' do
-    before { post "/?logoutRequest=#{URI.encode(fixture('single_sign_out_request.xml'))}" }
+    before { post "/?logoutRequest=#{URI::Parser.new.escape(fixture('single_sign_out_request.xml'))}" }
     its(:ticket) { should eql 'ST-0123456789ABCDEFGHIJKLMNOPQRS' }
     its(:single_sign_out?) { should be true }
     its(:logout?) { should be false }

--- a/spec/rack/cas_spec.rb
+++ b/spec/rack/cas_spec.rb
@@ -65,7 +65,7 @@ describe Rack::CAS do
       { session_store: session_store }
     }
 
-    subject { post "/?logoutRequest=#{URI.encode(fixture('single_sign_out_request.xml'))}" }
+    subject { post "/?logoutRequest=#{URI::Parser.new.escape(fixture('single_sign_out_request.xml'))}" }
     its(:status) { should eql 200 }
     its(:body) { should eql 'CAS Single-Sign-Out request intercepted.' }
   end


### PR DESCRIPTION
Allows custom parameters to be passed to the serviceValidate endpoint on CAS servers.
Also make rspec work with ruby 3.